### PR TITLE
♻️ コレクションクラスをvectorのprivate継承にした

### DIFF
--- a/SmallEnginePlus/Geometry.cpp
+++ b/SmallEnginePlus/Geometry.cpp
@@ -5,7 +5,7 @@
 /// コンストラクタ(頂点インデックスあり)
 /// </summary>
 /// <param name="triangles"></param>
-Geometry::Geometry (VertexCollection vertices, VertexIndex indices) {
+Geometry::Geometry (vector<Vertex> vertices, VertexIndex indices) {
 	m_vertices = std::move (vertices);
 	m_indices = std::move (indices);
 }
@@ -14,7 +14,7 @@ Geometry::Geometry (VertexCollection vertices, VertexIndex indices) {
 /// コンストラクタ(頂点インデックスなし)
 /// </summary>
 /// <param name="triangles"></param>
-Geometry::Geometry (VertexCollection vertices) {
+Geometry::Geometry (vector<Vertex> vertices) {
 	m_vertices = std::move (vertices);
 }
 
@@ -35,7 +35,7 @@ Geometry::~Geometry () {
 /// 頂点情報を取得する
 /// </summary>
 /// <returns>頂点情報</returns>
-VertexCollection Geometry::GetVertices () {
+vector<Vertex> Geometry::GetVertices () {
 	return m_vertices;
 }
 
@@ -53,7 +53,7 @@ Geometry Geometry::CreateGeometryFromXMFloat3Array (vector<XMFLOAT3> vertexPosit
 Geometry Geometry::CreateGeometryFromPosAndIndex (vector<XMFLOAT3> vertexPositions, vector<DWORD> indicesData)
 {
 	auto vertices = Vertex::CreateVerticesFromXMFLOAT3Array (vertexPositions);
-	auto indices = VertexIndex (indicesData);
+	VertexIndex indices = move(indicesData);
 
 	return Geometry (vertices, indices);
 }

--- a/SmallEnginePlus/Geometry.h
+++ b/SmallEnginePlus/Geometry.h
@@ -3,7 +3,6 @@
 #include "Vertex.h"
 #include "VertexIndex.h"
 #include "VertexBuffer.h"
-#include "VertexCollection.h"
 
 using namespace std;
 using winrt::com_ptr;
@@ -19,13 +18,13 @@ public:
 	/// </summary>
 	/// <param name="vertices">頂点</param>
 	/// <param name="indices">頂点インデックス</param>
-	Geometry (VertexCollection vertices, VertexIndex indices);
+	Geometry (vector<Vertex> vertices, VertexIndex indices);
 
 	/// <summary>
 	/// コンストラクタ(頂点インデックスなし)
 	/// </summary>
 	/// <param name="vertices">頂点</param>
-	Geometry (VertexCollection vertices);
+	Geometry (vector<Vertex> vertices);
 
 	/// <summary>
 	/// デストラクタ
@@ -48,7 +47,7 @@ public:
 	/// 頂点情報を取得する
 	/// </summary>
 	/// <returns>頂点情報</returns>
-	VertexCollection GetVertices ();
+	vector<Vertex> GetVertices ();
 
 	/// <summary>
 	/// 頂点インデックスを取得する
@@ -89,7 +88,7 @@ private:
 	/// <summary>
 	/// 頂点群
 	/// </summary>
-	VertexCollection m_vertices;
+	vector<Vertex> m_vertices;
 
 	/// <summary>
 	/// 頂点インデックス

--- a/SmallEnginePlus/GeometryCollection.cpp
+++ b/SmallEnginePlus/GeometryCollection.cpp
@@ -2,23 +2,18 @@
 #include "GeometryCollection.h"
 
 /// <summary>
-/// コンストラクタ
-/// </summary>
-/// <param name="geometries">Geometryの配列</param>
-GeometryCollection::GeometryCollection (vector<Geometry> geometries)
-{
-    m_geometries = geometries;
-    m_vertexNum = CountVertexNum ();
-    m_indexNum = CountIndexNum ();
-}
-
-/// <summary>
 /// 形状に含まれる全ての頂点数を返す
 /// </summary>
 /// <returns></returns>
 UINT GeometryCollection::GetVertexNum ()
 {
-    return m_vertexNum;
+    UINT vertexNum = 0;
+
+    for (auto geometry: *this) {
+        vertexNum += geometry.GetVertexNum ();
+    }
+
+    return vertexNum;
 }
 
 /// <summary>
@@ -27,7 +22,13 @@ UINT GeometryCollection::GetVertexNum ()
 /// <returns></returns>
 UINT GeometryCollection::GetIndexNum ()
 {
-    return m_indexNum;
+    UINT indexNum = 0;
+
+    for (auto geometry: *this) {
+        indexNum += geometry.GetIndexNum ();
+    }
+
+    return indexNum;
 }
 
 /// <summary>
@@ -51,18 +52,23 @@ UINT GeometryCollection::GetIndicesSize ()
 /// <summary>
 /// 全ての頂点情報を取得する
 /// </summary>
-VertexCollection GeometryCollection::GetVertices ()
+vector<Vertex> GeometryCollection::GetVertices ()
 {
-    VertexCollection allVertices;
+    vector<Vertex> allVertices;
 
-    for (auto geometry : m_geometries) {
-        auto vertices = geometry.GetVertices ();
-
-        // 末尾に配列を追加
-        allVertices.insert (allVertices.end (), vertices.begin (), vertices.end ());
+    // 自身の要素を1つずつ取り出して処理する
+    for (auto& geometry : *this) {
+        auto vertices = geometry.GetVertices();
+        allVertices.reserve(allVertices.size() + vertices.size());
+        allVertices.insert(allVertices.end(), vertices.begin(), vertices.end());
     }
 
     return allVertices;
+}
+
+UINT GeometryCollection::GetVerticesSize ()
+{
+    return GetVertices().size() * sizeof(XMVECTOR);
 }
 
 /// <summary>
@@ -73,8 +79,9 @@ VertexIndex GeometryCollection::GetIndices ()
 {
     VertexIndex allIndices;
 
-    for (auto geometry : m_geometries) {
+    for (auto& geometry : *this) {
         auto indices = geometry.GetIndices ();
+        allIndices.reserve (allIndices.size () + indices.size());
         allIndices.insert (allIndices.end (), indices.begin (), indices.end ());
     }
 
@@ -88,7 +95,7 @@ VertexIndex GeometryCollection::GetIndices ()
 UINT GeometryCollection::CountVertexNum ()
 {
     UINT vertexNum = 0;
-    for (auto geometry : m_geometries) {
+    for (auto& geometry : *this) {
         vertexNum += geometry.GetVertexNum ();
     }
 
@@ -102,76 +109,9 @@ UINT GeometryCollection::CountVertexNum ()
 UINT GeometryCollection::CountIndexNum ()
 {
     UINT indexNum = 0;
-    for (auto geometry : m_geometries) {
+    for (auto& geometry : *this) {
         indexNum += geometry.GetIndexNum ();
     }
 
     return indexNum;
 }
-
-/// <summary>
-/// 配列の末尾に要素を追加する
-/// </summary>
-/// <param name="geometry">追加する要素</param>
-void GeometryCollection::push_back (Geometry geometry)
-{
-    m_geometries.push_back (geometry);
-    m_vertexNum += geometry.GetVertexNum();
-    m_indexNum += geometry.GetIndexNum();
-}
-
-/// <summary>
-/// 配列の先頭ポインタを返す
-/// </summary>
-/// <returns>配列の先頭ポインタ</returns>
-Geometry* GeometryCollection::data () {
-    return m_geometries.data ();
-}
-
-/// <summary>
-/// 配列の終了地点を示すイテレーターを返す
-/// </summary>
-/// <returns></returns>
-typename vector<Geometry>::const_iterator GeometryCollection::end () {
-    return m_geometries.end ();
-}
-
-typename vector<Geometry>::const_iterator GeometryCollection::begin ()
-{
-    return m_geometries.begin ();
-}
-
-/// <summary>
-/// targetPosの位置に配列を挿入する
-/// </summary>
-/// <param name="targetPos">挿入先</param>
-/// <param name="begin">挿入する配列の開始地点</param>
-/// <param name="end">挿入する配列の終了地点</param>
-/// <returns></returns>
-typename vector<Geometry>::const_iterator GeometryCollection::insert 
-(
-    typename vector<Geometry>::const_iterator targetPos, 
-    typename vector<Geometry>::const_iterator begin, 
-    typename vector<Geometry>::const_iterator end
-){
-    return m_geometries.insert (targetPos, begin, end);
-}
-
-/// <summary>
-/// 配列の要素数を返す
-/// </summary>
-/// <returns></returns>
-size_t GeometryCollection::size ()
-{
-    return m_geometries.size();
-}
-
-/// <summary>
-/// 配列要素を全て削除
-/// </summary>
-void GeometryCollection::clear ()
-{
-    m_geometries.clear ();
-    m_vertexNum = 0;
-}
-

--- a/SmallEnginePlus/GeometryCollection.h
+++ b/SmallEnginePlus/GeometryCollection.h
@@ -2,22 +2,13 @@
 #include "pch.h"
 #include "Geometry.h"
 #include "VertexIndex.h"
-#include "VertexCollection.h"
-#include "ICollection.h"
 
 /// <summary>
 /// Geometryの配列
 /// </summary>
-class GeometryCollection : public ICollection<class Geometry>
+class GeometryCollection : private vector<Geometry>
 {
 public:
-	GeometryCollection () {};
-
-	/// <summary>
-	/// コンストラクタ
-	/// </summary>
-	/// <param name="geometries">Geometryの配列</param>
-	GeometryCollection (vector<Geometry> geometries);
 
 	/// <summary>
 	/// 形状内に存在する全ての頂点数を返す
@@ -34,7 +25,13 @@ public:
 	/// <summary>
 	/// 全ての頂点情報を取得する
 	/// </summary>
-	VertexCollection GetVertices ();
+	vector<Vertex> GetVertices ();
+
+	/// <summary>
+	/// 頂点のバイト数を返す
+	/// </summary>
+	/// <returns></returns>
+	UINT GetVerticesSize ();
 
 	/// <summary>
 	/// 全ての頂点インデックスを取得する
@@ -55,59 +52,17 @@ public:
 	UINT GetIndexNum ();
 
 
-
 	//***************************/
-	// ICollectionの純粋仮想関数
+	// vectorクラスの関数		
 	//***************************/
 
-	/// <summary>
-	/// 配列の末尾に要素を追加する
-	/// </summary>
-	/// <param name="geometry">追加する要素</param>
-	void push_back (Geometry geometry);
-
-	/// <summary>
-	/// 配列の先頭ポインタを返す
-	/// </summary>
-	/// <returns>配列の先頭ポインタ</returns>
-	Geometry* data ();
-
-	/// <summary>
-	/// 配列の開始地点を示すイテレーターを返す
-	/// </summary>
-	/// <returns></returns>
-	typename vector<Geometry>::const_iterator begin ();
-
-	/// <summary>
-	/// 配列の終了地点を示すイテレーターを返す
-	/// </summary>
-	/// <returns></returns>
-	typename vector<Geometry>::const_iterator end ();
-
-	/// <summary>
-	/// targetPosの位置に配列を挿入する
-	/// </summary>
-	/// <param name="targetPos">挿入先</param>
-	/// <param name="begin">挿入する配列の開始地点</param>
-	/// <param name="end">挿入する配列の終了地点</param>
-	/// <returns></returns>
-	typename vector<Geometry>::const_iterator insert 
-	(
-		typename vector<Geometry>::const_iterator targetPos, 
-		typename vector<Geometry>::const_iterator begin, 
-		typename vector<Geometry>::const_iterator end
-	);
-
-	/// <summary>
-	/// 配列の要素数を返す
-	/// </summary>
-	/// <returns></returns>
-	size_t size ();
-
-	/// <summary>
-	/// 配列要素を全て削除
-	/// </summary>
-	void clear ();
+	using vector::push_back;
+	using vector::data;
+	using vector::begin;
+	using vector::end;
+	using vector::insert;
+	using vector::size;
+	using vector::clear;
 
 private:
 	/// <summary>
@@ -121,11 +76,6 @@ private:
 	/// </summary>
 	/// <returns>全頂点インデックス数</returns>
 	UINT CountIndexNum ();
-
-	/// <summary>
-	/// 形状の配列
-	/// </summary>
-	vector<Geometry> m_geometries;
 
 	/// <summary>
 	/// 全頂点数

--- a/SmallEnginePlus/ResourceFactory.cpp
+++ b/SmallEnginePlus/ResourceFactory.cpp
@@ -21,7 +21,7 @@ com_ptr<VertexBuffer> ResourceFactory::CreateVertexBufferByGeometries (com_ptr<I
 	// 頂点配列からプリミティブな座標の配列を生成
 	auto vertices = geometries.GetVertices ();
 
-	memcpy (pVertexDataBegin.get(), vertices.data(), vertices.GetVerticesSize());
+	memcpy (pVertexDataBegin.get(), vertices.data(), geometries.GetVerticesSize());
 	vertexBuffer->Unmap (0, NULL);
 
 	return vertexBuffer;

--- a/SmallEnginePlus/SmallEnginePlus.vcxproj
+++ b/SmallEnginePlus/SmallEnginePlus.vcxproj
@@ -147,7 +147,6 @@
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="Direct3D.h" />
     <ClInclude Include="GeometryCollection.h" />
-    <ClInclude Include="ICollection.h" />
     <ClInclude Include="IndexBuffer.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Renderer.h" />
@@ -158,21 +157,18 @@
     <ClInclude Include="targetver.h" />
     <ClInclude Include="Vertex.h" />
     <ClInclude Include="VertexBuffer.h" />
-    <ClInclude Include="VertexCollection.h" />
     <ClInclude Include="VertexIndex.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Direct3D.cpp" />
     <ClCompile Include="Geometry.cpp" />
     <ClCompile Include="GeometryCollection.cpp" />
-    <ClCompile Include="ICollection.cpp" />
     <ClCompile Include="IndexBuffer.cpp" />
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="ResourceFactory.cpp" />
     <ClCompile Include="SmallEnginePlus.cpp" />
     <ClCompile Include="Vertex.cpp" />
     <ClCompile Include="VertexBuffer.cpp" />
-    <ClCompile Include="VertexCollection.cpp" />
     <ClCompile Include="VertexIndex.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/SmallEnginePlus/SmallEnginePlus.vcxproj.filters
+++ b/SmallEnginePlus/SmallEnginePlus.vcxproj.filters
@@ -18,17 +18,11 @@
     <Filter Include="ソース ファイル\Resources">
       <UniqueIdentifier>{4c83b776-44cf-4169-86ad-2d7a8adfb022}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ソース ファイル\Common">
-      <UniqueIdentifier>{11221e01-d7ed-4f51-8456-6d9bf1d5aba5}</UniqueIdentifier>
-    </Filter>
     <Filter Include="ソース ファイル\Geometry\Vertex">
       <UniqueIdentifier>{2da0b928-d764-4af1-b888-86a424a63aca}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ソース ファイル\Collection">
-      <UniqueIdentifier>{7cf53954-95bf-4ede-8691-c2345d5d838f}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="ソース ファイル\Collection\Interface">
-      <UniqueIdentifier>{e88afd0d-3ad5-4532-846b-72e87fd69e1a}</UniqueIdentifier>
+    <Filter Include="ソース ファイル\Geometry\VertexIndex">
+      <UniqueIdentifier>{8d945f09-1482-45c0-9c3a-4cfa3d632b14}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -68,17 +62,11 @@
     <ClInclude Include="Vertex.h">
       <Filter>ソース ファイル\Geometry\Vertex</Filter>
     </ClInclude>
-    <ClInclude Include="GeometryCollection.h">
-      <Filter>ソース ファイル\Collection</Filter>
-    </ClInclude>
-    <ClInclude Include="VertexCollection.h">
-      <Filter>ソース ファイル\Collection</Filter>
-    </ClInclude>
-    <ClInclude Include="ICollection.h">
-      <Filter>ソース ファイル\Collection\Interface</Filter>
-    </ClInclude>
     <ClInclude Include="VertexIndex.h">
-      <Filter>ソース ファイル\Collection</Filter>
+      <Filter>ソース ファイル\Geometry\VertexIndex</Filter>
+    </ClInclude>
+    <ClInclude Include="GeometryCollection.h">
+      <Filter>ソース ファイル\Geometry</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -106,17 +94,11 @@
     <ClCompile Include="Vertex.cpp">
       <Filter>ソース ファイル\Geometry\Vertex</Filter>
     </ClCompile>
-    <ClCompile Include="GeometryCollection.cpp">
-      <Filter>ソース ファイル\Collection</Filter>
-    </ClCompile>
-    <ClCompile Include="VertexCollection.cpp">
-      <Filter>ソース ファイル\Collection</Filter>
-    </ClCompile>
-    <ClCompile Include="ICollection.cpp">
-      <Filter>ソース ファイル\Collection\Interface</Filter>
-    </ClCompile>
     <ClCompile Include="VertexIndex.cpp">
-      <Filter>ソース ファイル\Collection</Filter>
+      <Filter>ソース ファイル\Geometry\VertexIndex</Filter>
+    </ClCompile>
+    <ClCompile Include="GeometryCollection.cpp">
+      <Filter>ソース ファイル\Geometry</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/SmallEnginePlus/Vertex.cpp
+++ b/SmallEnginePlus/Vertex.cpp
@@ -28,8 +28,8 @@ XMVECTOR Vertex::GetXMVECTORPosition ()
 /// </summary>
 /// <param name="positions">頂点座標群</param>
 /// <returns>頂点情報の配列</returns>
-VertexCollection Vertex::CreateVerticesFromXMFLOAT3Array (vector<XMFLOAT3> positions) {
-	VertexCollection vertexArray = {};
+vector<Vertex> Vertex::CreateVerticesFromXMFLOAT3Array (vector<XMFLOAT3> positions) {
+	vector<Vertex> vertexArray = {};
 
 	// positionsからpositionを取り出し、Vertexオブジェクトを生成
 	for (const auto position : positions) {

--- a/SmallEnginePlus/Vertex.h
+++ b/SmallEnginePlus/Vertex.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "pch.h"
-#include "VertexCollection.h"
 
 /// <summary>
 /// 頂点情報を持つクラス
@@ -30,7 +29,7 @@ public:
 	/// </summary>
 	/// <param name="positions">頂点座標群</param>
 	/// <returns>頂点情報の配列</returns>
-	static class VertexCollection CreateVerticesFromXMFLOAT3Array (vector<XMFLOAT3> positions);
+	static class vector<Vertex> CreateVerticesFromXMFLOAT3Array (vector<XMFLOAT3> positions);
 private:
 	/// <summary>
 	/// 頂点座標

--- a/SmallEnginePlus/VertexIndex.cpp
+++ b/SmallEnginePlus/VertexIndex.cpp
@@ -1,18 +1,7 @@
 #include "pch.h"
 #include "VertexIndex.h"
 
-/// <summary>
-/// コンストラクタ
-/// </summary>
-/// <param name="indices">頂点インデックス</param>
-VertexIndex::VertexIndex (vector<DWORD> indices) {
-	m_indices = indices;
-}
-
-/// <summary>
-/// デストラクタ
-/// </summary>
-VertexIndex::~VertexIndex (){}
+VertexIndex::VertexIndex (vector<DWORD> &&indicesData) : vector<DWORD>(move(indicesData)){}
 
 /// <summary>
 /// 頂点インデックスのバイト数を返す
@@ -20,69 +9,5 @@ VertexIndex::~VertexIndex (){}
 /// <returns>頂点インデックスのバイト数</returns>
 UINT VertexIndex::GetIndicesSize () 
 {
-	return m_indices.size () * sizeof (DWORD);
+	return this->size () * sizeof (DWORD);
 }
-
-/// <summary>
-/// 配列の末尾に要素を追加する
-/// </summary>
-/// <param name="index">追加する要素</param>
-void VertexIndex::push_back (DWORD index)
-{
-    m_indices.push_back (index);
-}
-
-/// <summary>
-/// 配列の先頭ポインタを返す
-/// </summary>
-/// <returns>配列の先頭ポインタ</returns>
-DWORD* VertexIndex::data () {
-    return m_indices.data ();
-}
-
-/// <summary>
-/// 配列の終了地点を示すイテレーターを返す
-/// </summary>
-/// <returns></returns>
-typename vector<DWORD>::const_iterator VertexIndex::end () {
-    return m_indices.end ();
-}
-
-typename vector<DWORD>::const_iterator VertexIndex::begin ()
-{
-    return m_indices.begin ();
-}
-
-/// <summary>
-/// targetPosの位置に配列を挿入する
-/// </summary>
-/// <param name="targetPos">挿入先</param>
-/// <param name="begin">挿入する配列の開始地点</param>
-/// <param name="end">挿入する配列の終了地点</param>
-/// <returns></returns>
-typename vector<DWORD>::const_iterator VertexIndex::insert
-(
-    typename vector<DWORD>::const_iterator targetPos,
-    typename vector<DWORD>::const_iterator begin,
-    typename vector<DWORD>::const_iterator end
-) {
-    return m_indices.insert (targetPos, begin, end);
-}
-
-/// <summary>
-/// 配列の要素数を返す
-/// </summary>
-/// <returns></returns>
-size_t VertexIndex::size ()
-{
-    return m_indices.size ();
-}
-
-/// <summary>
-/// 配列要素を全て削除
-/// </summary>
-void VertexIndex::clear ()
-{
-    m_indices.clear ();
-}
-

--- a/SmallEnginePlus/VertexIndex.h
+++ b/SmallEnginePlus/VertexIndex.h
@@ -5,20 +5,11 @@
 /// <summary>
 /// 頂点インデックス
 /// </summary>
-class VertexIndex: public ICollection<DWORD>
+class VertexIndex: private vector<DWORD>
 {
 public:
-	VertexIndex () {};
-	/// <summary>
-	/// コンストラクタ
-	/// </summary>
-	/// <param name="indices">頂点インデックス</param>
-	VertexIndex (vector<DWORD> indices);
-
-	/// <summary>
-	/// デストラクタ
-	/// </summary>
-	~VertexIndex ();
+	VertexIndex () {}
+	VertexIndex (vector<DWORD> &&indicecsData);
 
 	/// <summary>
 	/// 頂点インデックスのバイト数を返す
@@ -26,62 +17,17 @@ public:
 	/// <returns>頂点インデックスのバイト数</returns>
 	UINT GetIndicesSize ();
 
+
 	//***************************/
-	// ICollectionの純粋仮想関数
+	// vectorクラスの関数
 	//***************************/
 
-	/// <summary>
-	/// 配列の末尾に要素を追加する
-	/// </summary>
-	/// <param name="geometry">追加する要素</param>
-	void push_back (DWORD geometry);
-
-	/// <summary>
-	/// 配列の先頭ポインタを返す
-	/// </summary>
-	/// <returns>配列の先頭ポインタ</returns>
-	DWORD* data ();
-
-	/// <summary>
-	/// 配列の開始地点を示すイテレーターを返す
-	/// </summary>
-	/// <returns></returns>
-	typename vector<DWORD>::const_iterator begin ();
-
-	/// <summary>
-	/// 配列の終了地点を示すイテレーターを返す
-	/// </summary>
-	/// <returns></returns>
-	typename vector<DWORD>::const_iterator end ();
-
-	/// <summary>
-	/// targetPosの位置に配列を挿入する
-	/// </summary>
-	/// <param name="targetPos">挿入先</param>
-	/// <param name="begin">挿入する配列の開始地点</param>
-	/// <param name="end">挿入する配列の終了地点</param>
-	/// <returns></returns>
-	typename vector<DWORD>::const_iterator insert
-	(
-		typename vector<DWORD>::const_iterator targetPos,
-		typename vector<DWORD>::const_iterator begin,
-		typename vector<DWORD>::const_iterator end
-	);
-
-	/// <summary>
-	/// 配列の要素数を返す
-	/// </summary>
-	/// <returns></returns>
-	size_t size ();
-
-	/// <summary>
-	/// 配列要素を全て削除
-	/// </summary>
-	void clear ();
-
-private:
-	/// <summary>
-	/// 頂点インデックス
-	/// </summary>
-	vector<DWORD> m_indices;
+	using vector::push_back;
+	using vector::data;
+	using vector::begin;
+	using vector::end;
+	using vector::insert;
+	using vector::size;
+	using vector::clear;
+	using vector::reserve;
 };


### PR DESCRIPTION
VertexやらGeometryはvectorクラスのインスタンスを中に抱え込むように実装していたが
private継承すれば機能を抱え込めるからそのように変更。

あと必要のないクラスも消した。